### PR TITLE
Added support for string based ids

### DIFF
--- a/src/main/scala/org/scaloid/common/Context.scala
+++ b/src/main/scala/org/scaloid/common/Context.scala
@@ -57,6 +57,8 @@ import android.view.View._
 import android.graphics.drawable.Drawable
 import java.lang.CharSequence
 import scala.Int
+import scala.collection.mutable.HashMap
+import scala.collection.mutable.Map
 import android.view.ContextMenu.ContextMenuInfo
 import android.text.method._
 import android.gesture._
@@ -141,8 +143,12 @@ trait TraitActivity[V <: Activity] {
     @inline def contentView: View = null
 
     def basis: Activity
+    implicit val idMap: Map[String, Int]
 
     def find[V <: View](id: Int): V = basis.findViewById(id).asInstanceOf[V]
+
+    def find[V <: View](id: String): V = find[V](idMap(id))
+
 
     def runOnUiThread (f: => Unit)  {
       if(uiThread == Thread.currentThread) {
@@ -157,9 +163,11 @@ trait TraitActivity[V <: Activity] {
     }
   }
 
+
 trait SActivity extends Activity with SContext with TraitActivity[SActivity] with Destroyable with Creatable with Registerable {
   def basis = this
   override implicit val ctx = this
+  implicit val idMap = new HashMap[String, Int] ()
 
   def onRegister(body: => Any) = onResume(body)
   def onUnregister(body: => Any) = onPause(body)

--- a/src/main/scala/org/scaloid/common/Widget.scala
+++ b/src/main/scala/org/scaloid/common/Widget.scala
@@ -57,6 +57,7 @@ import android.view.View._
 import android.graphics.drawable.Drawable
 import java.lang.CharSequence
 import scala.Int
+import scala.collection.mutable.Map
 import android.view.ContextMenu.ContextMenuInfo
 import android.text.method._
 import android.gesture._
@@ -110,6 +111,8 @@ trait WidgetFamily {
   trait TraitView[V <: View] extends ConstantsSupport {
 
     def find[V <: View](id: Int): V = basis.findViewById(id).asInstanceOf[V]
+    
+    def find[V <: View](id: String)(implicit idMap: Map[String, Int]): V = find[V](idMap(id))
 
     @inline def onClick(f:  => Unit): V = {
       basis.setOnClickListener(new OnClickListener {
@@ -300,10 +303,23 @@ trait WidgetFamily {
     @inline def horizontalScrollBarEnabled_=(p: Boolean) = { basis.setHorizontalScrollBarEnabled    (p); basis }
     @inline def  enableHorizontalScrollBar               = { basis.setHorizontalScrollBarEnabled(true ); basis }
     @inline def disableHorizontalScrollBar               = { basis.setHorizontalScrollBarEnabled(false); basis }
-
+   
     @inline def id = basis.getId
     @inline def id  (p: Int) =            id_=  (p)
+    def id  (s: String) (implicit idMap: Map[String, Int], activity: Activity): V = {
+      if ( !idMap.contains(s)) 
+        idMap += s -> getUniqueId
+
+      id(idMap(s))
+    }
+
     @inline def id_=(p: Int) = { basis.setId    (p); basis }
+    def id_=(s: String) (implicit idMap: Map[String, Int], activity: Activity): V = {
+      if ( !idMap.contains(s)) 
+        idMap += s -> getUniqueId
+
+      id_=(idMap(s))
+    }
 
     @inline def inEditMode = basis.isInEditMode
 


### PR DESCRIPTION
I really love the way scaloid lets you build UIs without using XML. But unfornatetly support for ids is bad. The only way I was able to give UI elements ids in scaloid is by first defining the id in a xml resource. 

In `res/values/ids.xml`

``` xml
<?xml version="1.0" encoding="utf-8"?>
<resources>
    <item type="id" name="email" />
</resources>
```

In `MainActivity.scala`

``` scala
SEditText().id(R.id.email)
```

Since this seems rather annoying and not on par with the rest of scaloid I introduced support for dynamic ids based on strings

In `MainActivity.scala`:

``` scala
SEditText().id("email")

find[SEditText]("email")
```
