### PR TITLE
TraitAbsListView extends TraitAdapterView directly (enhance #16)

### DIFF
--- a/src/main/scala/org/scaloid/common/Widget.scala
+++ b/src/main/scala/org/scaloid/common/Widget.scala
@@ -929,7 +929,7 @@ trait WidgetFamily {
 
   }
 
-  trait TraitAbsListView[V <: AbsListView] extends TraitView[V] {
+  trait TraitAbsListView[V <: AbsListView] extends TraitAdapterView[V] {
     @inline def cacheColorHint = basis.getCacheColorHint
     @inline def cacheColorHint  (p: Int) =            cacheColorHint_=  (p)
     @inline def cacheColorHint_=(p: Int) = { basis.setCacheColorHint    (p); basis }

--- a/src/main/st/org/scaloid/common/Widget.scala
+++ b/src/main/st/org/scaloid/common/Widget.scala
@@ -132,7 +132,7 @@ $endif$
 
   $wholeClassDef(android.widget.TextView, "TraitView[V]")$
 
-  trait TraitAbsListView[V <: AbsListView] extends TraitView[V] {
+  trait TraitAbsListView[V <: AbsListView] extends TraitAdapterView[V] {
     $properties(android.widget.AbsListView)$
   }
 
@@ -417,18 +417,18 @@ $endif$
     orientation = VERTICAL
   }
 
-  $wholeClassDef(android.widget.EditText, "TraitTextView[V]", textViewBody)$
-  $wholeClassDef(android.inputmethodservice.ExtractEditText, "TraitEditText[V]", textViewBody)$
-  $wholeClassDef(android.widget.AutoCompleteTextView, "TraitEditText[V]", textViewBody)$
+  $wholeClassDef(android.widget.EditText, "TraitTextView[V]")$
+  $wholeClassDef(android.inputmethodservice.ExtractEditText, "TraitEditText[V]")$
+  $wholeClassDef(android.widget.AutoCompleteTextView, "TraitEditText[V]")$
   $wholeClassDef(android.widget.ListView, "TraitAbsListView[V]")$
-  $wholeClassDef(android.widget.Button, "TraitTextView[V]", buttonObjectBody)$
+  $wholeClassDef(android.widget.Button, "TraitTextView[V]")$
   $wholeClassDef(android.widget.CompoundButton, "TraitButton[V]")$
-  $wholeClassDef(android.widget.CheckBox, "TraitCompoundButton[V]", buttonObjectBody)$
-  $wholeClassDef(android.widget.RadioButton, "TraitCompoundButton[V]", buttonObjectBody)$
-  $wholeClassDef(android.widget.ToggleButton, "TraitCompoundButton[V]", buttonObjectBody)$
-  $wholeClassDef(android.widget.CheckedTextView, "TraitTextView[V]", textviewBody)$
-  $wholeClassDef(android.widget.Chronometer, "TraitTextView[V]", textviewBody)$
-  $wholeClassDef(android.widget.DigitalClock, "TraitTextView[V]", textviewBody)$
+  $wholeClassDef(android.widget.CheckBox, "TraitCompoundButton[V]")$
+  $wholeClassDef(android.widget.RadioButton, "TraitCompoundButton[V]")$
+  $wholeClassDef(android.widget.ToggleButton, "TraitCompoundButton[V]")$
+  $wholeClassDef(android.widget.CheckedTextView, "TraitTextView[V]")$
+  $wholeClassDef(android.widget.Chronometer, "TraitTextView[V]")$
+  $wholeClassDef(android.widget.DigitalClock, "TraitTextView[V]")$
   $richClassDef(android.inputmethodservice.KeyboardView, "TraitView[V]")$
   $wholeClassDef(android.widget.ImageView, "TraitView[V]")$
   $wholeClassDef(android.widget.ImageButton, "TraitImageView[V]")$


### PR DESCRIPTION
I found that `TraitAdapterView` is not mixed in `TraitListView` after the migration to SBT.

Originally I mixed it like before, but after some research found that `android.widget.AbsListView` extends `android.widget.AdapterView` directly so I made `TraitAdapterView` as the direct parent of `TraitAbsListView`, which is extended by not only `TraitListView` but also `TraitGridView`.

As a result, more classes got missing members back.
