### PR TITLE
Regression with SContext

### DIFF
--- a/scaloid-common/src/main/st/org/scaloid/common/content.scala
+++ b/scaloid-common/src/main/st/org/scaloid/common/content.scala
@@ -53,6 +53,7 @@ trait Registerable {
 $wholeClassDef(android.content.Context)$
 
 trait SContext extends Context with TraitContext[SContext] with TagUtil {
+  def basis: SContext = this
 }
 
 $wholeClassDef(android.content.ContextWrapper)$


### PR DESCRIPTION
SContext implementers have to override the method "def basis: SContext" unlike in the previous version.
