### PR TITLE
Optionally allow flags to be passed to pendingActivity/pendingService

### DIFF
--- a/scaloid-common/src/main/scala/org/scaloid/common/helpers.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/helpers.scala
@@ -69,14 +69,14 @@ trait AppHelpers {
     context.startActivity(new Intent(Intent.ACTION_VIEW, uri))
   }
 
-  @inline def pendingService(intent: Intent)(implicit context: Context) =
-    PendingIntent.getService(context, 0, intent, 0)
+  @inline def pendingService(intent: Intent, flags: Int = 0)(implicit context: Context) =
+    PendingIntent.getService(context, 0, intent, flags)
 
-  @inline def pendingActivity(intent: Intent)(implicit context: Context) =
-    PendingIntent.getActivity(context, 0, intent, 0)
+  @inline def pendingActivity(intent: Intent, flags: Int = 0)(implicit context: Context) =
+    PendingIntent.getActivity(context, 0, intent, flags)
 
-  @inline def pendingActivity[T](implicit context: Context, mt: ClassTag[T]) =
-    PendingIntent.getActivity(context, 0, SIntent[T], 0)
+  @inline def pendingActivity[T](flags: Int = 0)(implicit context: Context, mt: ClassTag[T]) =
+    PendingIntent.getActivity(context, 0, SIntent[T], flags)
 
 }
 


### PR DESCRIPTION
Allows consuming code to set options such as
PendingIntent.FLAG_UPDATE_CURRENT
