### PR TITLE
Cross build with Scala 2.10.4

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -27,6 +27,7 @@ object ScaloidBuild extends Build {
     organizationHomepage := Some(new URL("http://blog.scaloid.org")),
     description := "Less Painful Android Development with Scala",
     startYear := Some(2012),
+    scalaVersion := "2.10.4",
     crossScalaVersions := Seq("2.10.4", "2.11.0"),
     version := scaloidVersion,
     resolvers ++= Dependencies.resolutionRepos,


### PR DESCRIPTION
Enable SBT cross build [1]

To build against all versions, prefix the action to run with `+` like:

`> + publish`

[1] http://www.scala-sbt.org/0.13.2/docs/Detailed-Topics/Cross-Build.html
