### PR TITLE
Use 'Option.fold()()' instead of '.map()'.

### DIFF
--- a/scaloid-common/src/main/scala/org/scaloid/common/content.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/content.scala
@@ -393,7 +393,7 @@ class LocalServiceConnection[S <: LocalService](bindFlag: Int = Context.BIND_AUT
   var onDisconnected = new EventSource1[S, Unit]
 
   def run(f: S => Unit) {
-    if(service.isEmpty) onConnected(f) else service.map(f)
+    service.fold(onConnected(f))(f)
   }
 
   /**

--- a/scaloid-common/src/main/st/org/scaloid/common/content.scala
+++ b/scaloid-common/src/main/st/org/scaloid/common/content.scala
@@ -144,7 +144,7 @@ class LocalServiceConnection[S <: LocalService](bindFlag: Int = Context.BIND_AUT
   var onDisconnected = new EventSource1[S, Unit]
 
   def run(f: S => Unit) {
-    if(service.isEmpty) onConnected(f) else service.map(f)
+    service.fold(onConnected(f))(f)
   }
 
   /**


### PR DESCRIPTION
Option.fold()() is the preferred way to do if-else functional logic on Option, so this switches to that format.
