### PR TITLE
Update Build to Scala 2.11.4

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -27,7 +27,7 @@ object ScaloidBuild extends Build {
     description := "Less Painful Android Development with Scala",
     startYear := Some(2012),
     scalaVersion := "2.11.3",
-    crossScalaVersions := Seq("2.10.4", "2.11.3"),
+    crossScalaVersions := Seq("2.10.4", "2.11.4"),
     version := scaloidVersion,
     publishMavenStyle := true,
     publishTo <<= version {


### PR DESCRIPTION
As mentioned by Typesafe: 

> _Do Not Use Scala 2.11.3_
> Due to a binary incompatibility in Scala 2.11.3, we recommend upgrading to Scala 2.11.4, which resolves the incompatibility, as well as another blocker issue that was discovered in the days after the 2.11.3 release.
> cf: http://www.scala-lang.org/news/2.11.4
