### PR TITLE
Add evalOnUiThread() method, and make runOnUiThread() return Unit.

### DIFF
--- a/scaloid-common/src/main/scala/org/scaloid/common/app.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/app.scala
@@ -42,6 +42,8 @@ import android.os._
 import android.view._
 import android.view.WindowManager.LayoutParams._
 import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 import Implicits._
 import scala.deprecated
 
@@ -301,8 +303,9 @@ class AlertDialogBuilder(_title: CharSequence = null, _message: CharSequence = n
   /**
    * Shows the dialog that is currently building.
    * Because this method runs runOnUiThread internally, you can call this method from any thread.
+   * This method blocks until the dialog has been built in the UI thread.
    */
-  override def show(): AlertDialog = runOnUiThread(super.show())
+  override def show(): AlertDialog = Await.result(evalOnUiThread(super.show()), Duration.Inf)
 }
 
 /**

--- a/scaloid-common/src/main/scala/org/scaloid/common/helpers.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/helpers.scala
@@ -42,6 +42,7 @@ import android.net._
 import android.preference._
 import android.widget._
 import android.view._
+import scala.concurrent.Future
 import scala.reflect._
 
 trait AppHelpers {
@@ -207,8 +208,8 @@ trait WidgetHelpers {
    * Displays a dialog with spinner icon.
    * This method can be called from any threads.
    */
-  @inline def spinnerDialog(title: CharSequence, message: CharSequence)(implicit context: Context): ProgressDialog =
-    runOnUiThread(ProgressDialog.show(context, title, message, true))
+  @inline def spinnerDialog(title: CharSequence, message: CharSequence)(implicit context: Context): Future[ProgressDialog] =
+    evalOnUiThread(ProgressDialog.show(context, title, message, true))
 
 }
 

--- a/scaloid-common/src/main/st/org/scaloid/common/app.scala
+++ b/scaloid-common/src/main/st/org/scaloid/common/app.scala
@@ -9,6 +9,8 @@ import android.os._
 import android.view._
 import android.view.WindowManager.LayoutParams._
 import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 import Implicits._
 import scala.deprecated
 
@@ -271,8 +273,9 @@ class AlertDialogBuilder(_title: CharSequence = null, _message: CharSequence = n
   /**
    * Shows the dialog that is currently building.
    * Because this method runs runOnUiThread internally, you can call this method from any thread.
+   * This method blocks until the dialog has been built in the UI thread.
    */
-  override def show():AlertDialog = runOnUiThread(super.show())
+  override def show(): AlertDialog = Await.result(evalOnUiThread(super.show()), Duration.Inf)
 }
 
 /**

--- a/scaloid-common/src/main/st/org/scaloid/common/helpers.scala
+++ b/scaloid-common/src/main/st/org/scaloid/common/helpers.scala
@@ -9,6 +9,7 @@ import android.net._
 import android.preference._
 import android.widget._
 import android.view._
+import scala.concurrent.Future
 import scala.reflect._
 
 trait AppHelpers {
@@ -178,8 +179,8 @@ trait WidgetHelpers {
    * Displays a dialog with spinner icon.
    * This method can be called from any threads.
    */
-  @inline def spinnerDialog(title: CharSequence, message: CharSequence)(implicit context: Context): ProgressDialog =
-    runOnUiThread(ProgressDialog.show(context, title, message, true))
+  @inline def spinnerDialog(title: CharSequence, message: CharSequence)(implicit context: Context): Future[ProgressDialog] =
+    evalOnUiThread(ProgressDialog.show(context, title, message, true))
 
 }
 

--- a/scaloid-common/src/main/st/org/scaloid/common/package.scala
+++ b/scaloid-common/src/main/st/org/scaloid/common/package.scala
@@ -6,6 +6,8 @@ import android.os._
 import android.view._
 
 import language.implicitConversions
+import scala.concurrent._
+import scala.util.Try
 
 /**
  * Scaloid marries Android code with Scala resulting in easier to understand
@@ -62,16 +64,29 @@ package object common extends Logger with SystemServices with Helpers with Impli
 
   lazy val uiThread = Looper.getMainLooper.getThread
 
-  def runOnUiThread[T >: Null](f: => T): T = {
+  def runOnUiThread(f: => Unit): Unit = {
     if (uiThread == Thread.currentThread) {
-      return f
+      f
     } else {
       handler.post(new Runnable() {
         def run() {
           f
         }
       })
-      return null
+    }
+  }
+
+  def evalOnUiThread[T](f: => T): Future[T] = {
+    if (uiThread == Thread.currentThread) {
+      Future.fromTry(Try(f))
+    } else {
+      val p = Promise[T]()
+      handler.post(new Runnable() {
+        def run() {
+          p.complete(Try(f))
+        }
+      })
+      p.future
     }
   }
 


### PR DESCRIPTION
[NOTE: This change needs MAJOR TESTING on multiple Android versions. I'm not sure that this concurrency management will work correctly across versions, and this has had limited testing on only a 4.3 virtual machine/emulator.]


Some operations on the UI thread need to return values. In order to do so
safely, we need a method of enqueueing a computation behind a container
which supports a blocking wait for the result.

evalOnUiThread() takes a code block just like runOnUiThread(), but
returns a scala.concurrent.Future wrapper for the result. In most cases
this can be dereferenced by doing:

val res = Await.result(f, Duration.Inf)

which will block indefinitely in the current thread, waiting for the
submitted computation to execute on the UI thread. Once the computation
completes, either res will contain the successful result. If an exception
is thrown in the computation, or the it will be re-thrown in the *current*
thread where Await.result() is called.

If Await.result() (or other appropriate handling of the Future) is never
called, the result OR exception is discarded. Make sure to do something
with the Future so an exception result goes somewhere useful!

(By contrast, runOnUiThread() instead lets an exception bubble up the UI
thread's stack since it has nowhere else to send it. This also means that
evalOnUiThread() can be used for a code block which needs to propagate
an exception outside the UI thread but otherwise has no useful result.)

This change also alters two scaloid-internal methods which were depending
on the old behavior of getting a result from the call as a side effect of
already running in the UI thread. Instead, the result is Await'ed.

Thanks to PkmX@github for the basic implementation behind evalOnUiThread.

Fixes #118.