### PR TITLE
Propagate Android API deprecation warnings to scaloid-using code.

### DIFF
--- a/project/AndroidDomain.scala
+++ b/project/AndroidDomain.scala
@@ -23,15 +23,17 @@ case class AndroidMethod(
   retType: ScalaType,
   argTypes: List[ScalaType],
   paramedTypes: List[ScalaType],
-  isAbstract: Boolean = false,
-  isOverride: Boolean = false
+  isAbstract: Boolean,
+  isOverride: Boolean,
+  isDeprecated: Boolean
 )
 
 case class AndroidCallbackMethod(
   name: String,
   retType: ScalaType,
   argTypes: List[ScalaType],
-  hasBody: Boolean = true
+  hasBody: Boolean,
+  isDeprecated: Boolean
 )
 
 case class AndroidProperty(
@@ -51,7 +53,8 @@ case class AndroidListener(
   setter: String,
   setterArgTypes: List[ScalaType],
   callbackClassName: String,
-  callbackMethods: List[AndroidCallbackMethod]
+  callbackMethods: List[AndroidCallbackMethod],
+  isDeprecated: Boolean
 ) {
   def isSafe: Boolean =
     (! setter.startsWith("set")) || callbackMethods.length == 1 || callbackMethods.forall(_.retType.name == "Unit")
@@ -61,7 +64,8 @@ case class AndroidIntentMethod (
   name: String,
   retType: ScalaType,
   argTypes: List[ScalaType],
-  zeroArgs:Boolean
+  zeroArgs: Boolean,
+  isDeprecated: Boolean
 )
 
 case class ScalaConstructor(
@@ -69,7 +73,8 @@ case class ScalaConstructor(
   implicitArgs: List[Argument],
   explicitArgs: List[Argument],
   paramedTypes: List[ScalaType],
-  isVarArgs: Boolean
+  isVarArgs: Boolean,
+  isDeprecated: Boolean
 )
 
 case class AndroidClass(
@@ -84,6 +89,7 @@ case class AndroidClass(
   isA: Set[String],
   isAbstract: Boolean,
   isFinal: Boolean,
-  hasBlankConstructor: Boolean
+  hasBlankConstructor: Boolean,
+  isDeprecated: Boolean
 )
 

--- a/project/JavaConversionHelpers.scala
+++ b/project/JavaConversionHelpers.scala
@@ -30,6 +30,7 @@ trait JavaConversionHelpers {
         ).nonEmpty
       case None => false
     }
+  def isDeprecated(e: AnnotatedElement) = e.isAnnotationPresent(classOf[java.lang.Deprecated])
 
   def methodSignature(m: Method): String = List(
     m.getName,

--- a/project/StringUtils.scala
+++ b/project/StringUtils.scala
@@ -19,5 +19,7 @@ object StringUtils {
   def safeIdent(s: String) = if (s.matches("^[0-9].*") || reservedKeywordsNotInJava(s)) "`"+s+"`" else s
 
   def span(s: String, i: Int) = s.padTo(i, " ").mkString
+
+  val deprecatedDecl = """@deprecated("", "") """
 }
 

--- a/scaloid-common/src/main/scala/org/scaloid/common/SystemServices.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/SystemServices.scala
@@ -72,6 +72,8 @@ trait SystemServices {
     context.getSystemService(Context.ALARM_SERVICE).asInstanceOf[android.app.AlarmManager]
   @inline def audioManager(implicit context: Context) =
     context.getSystemService(Context.AUDIO_SERVICE).asInstanceOf[android.media.AudioManager]
+
+  // android.content.ClipboardManager in API 11+, but this is its superclass
   @inline def clipboardManager(implicit context: Context) =
     context.getSystemService(Context.CLIPBOARD_SERVICE).asInstanceOf[android.text.ClipboardManager]
 

--- a/scaloid-common/src/main/scala/org/scaloid/common/content.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/content.scala
@@ -203,37 +203,37 @@ trait TraitContext[V <: android.content.Context] {
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/content/Context.html#getWallpaper() getWallpaper()]]`
    */
-  @inline def wallpaper = basis.getWallpaper
+  @deprecated("", "") @inline def wallpaper = basis.getWallpaper
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/content/Context.html#setWallpaper(android.graphics.Bitmap) setWallpaper(android.graphics.Bitmap)]]`
    */
-  @inline def wallpaper(p: android.graphics.Bitmap) = wallpaper_=(p)
+  @deprecated("", "") @inline def wallpaper(p: android.graphics.Bitmap) = wallpaper_=(p)
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/content/Context.html#setWallpaper(android.graphics.Bitmap) setWallpaper(android.graphics.Bitmap)]]`
    */
-  @inline def wallpaper_=(p: android.graphics.Bitmap) = { basis.setWallpaper(p); basis }
+  @deprecated("", "") @inline def wallpaper_=(p: android.graphics.Bitmap) = { basis.setWallpaper(p); basis }
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/content/Context.html#setWallpaper(java.io.InputStream) setWallpaper(java.io.InputStream)]]`
    */
-  @inline def wallpaper(p: java.io.InputStream) = wallpaper_=(p)
+  @deprecated("", "") @inline def wallpaper(p: java.io.InputStream) = wallpaper_=(p)
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/content/Context.html#setWallpaper(java.io.InputStream) setWallpaper(java.io.InputStream)]]`
    */
-  @inline def wallpaper_=(p: java.io.InputStream) = { basis.setWallpaper(p); basis }
+  @deprecated("", "") @inline def wallpaper_=(p: java.io.InputStream) = { basis.setWallpaper(p); basis }
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/content/Context.html#getWallpaperDesiredMinimumHeight() getWallpaperDesiredMinimumHeight()]]`
    */
-  @inline def wallpaperDesiredMinimumHeight = basis.getWallpaperDesiredMinimumHeight
+  @deprecated("", "") @inline def wallpaperDesiredMinimumHeight = basis.getWallpaperDesiredMinimumHeight
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/content/Context.html#getWallpaperDesiredMinimumWidth() getWallpaperDesiredMinimumWidth()]]`
    */
-  @inline def wallpaperDesiredMinimumWidth = basis.getWallpaperDesiredMinimumWidth
+  @deprecated("", "") @inline def wallpaperDesiredMinimumWidth = basis.getWallpaperDesiredMinimumWidth
 
   @inline def bindService[T: ClassTag](p1: android.content.ServiceConnection, p2: Int)(implicit context: Context): Boolean = basis.bindService(SIntent[T], p1, p2)
 

--- a/scaloid-common/src/main/scala/org/scaloid/common/view.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/view.scala
@@ -102,7 +102,7 @@ trait TraitView[V <: android.view.View] extends ConstantsSupport with PressAndHo
     basis.getId
   }
 
-  val FILL_PARENT = ViewGroup.LayoutParams.FILL_PARENT
+  @deprecated("", "") val FILL_PARENT = ViewGroup.LayoutParams.FILL_PARENT
   val MATCH_PARENT = ViewGroup.LayoutParams.MATCH_PARENT
   val WRAP_CONTENT = ViewGroup.LayoutParams.WRAP_CONTENT
 
@@ -256,12 +256,12 @@ trait TraitView[V <: android.view.View] extends ConstantsSupport with PressAndHo
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/view/View.html#setBackgroundDrawable(android.graphics.drawable.Drawable) setBackgroundDrawable(android.graphics.drawable.Drawable)]]`
    */
-  @inline def backgroundDrawable(p: android.graphics.drawable.Drawable) = backgroundDrawable_=(p)
+  @deprecated("", "") @inline def backgroundDrawable(p: android.graphics.drawable.Drawable) = backgroundDrawable_=(p)
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/view/View.html#setBackgroundDrawable(android.graphics.drawable.Drawable) setBackgroundDrawable(android.graphics.drawable.Drawable)]]`
    */
-  @inline def backgroundDrawable_=(p: android.graphics.drawable.Drawable) = { basis.setBackgroundDrawable(p); basis }
+  @deprecated("", "") @inline def backgroundDrawable_=(p: android.graphics.drawable.Drawable) = { basis.setBackgroundDrawable(p); basis }
 
   @inline def backgroundResource(implicit no: NoGetterForThisProperty): Nothing = throw new Error("Android does not support the getter for 'backgroundResource'")
 

--- a/scaloid-common/src/main/scala/org/scaloid/common/widget.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/widget.scala
@@ -399,19 +399,19 @@ object SArrayAdapter {
 /**
  * Automatically generated enriching class of `[[https://developer.android.com/reference/android/widget/AbsoluteLayout.html android.widget.AbsoluteLayout]]`.
  */
-class RichAbsoluteLayout[V <: android.widget.AbsoluteLayout](val basis: V) extends TraitAbsoluteLayout[V]
+@deprecated("", "") class RichAbsoluteLayout[V <: android.widget.AbsoluteLayout](val basis: V) extends TraitAbsoluteLayout[V]
 
 /**
  * Automatically generated helper trait of `[[https://developer.android.com/reference/android/widget/AbsoluteLayout.html android.widget.AbsoluteLayout]]`. This contains several property accessors.
  */
-trait TraitAbsoluteLayout[V <: android.widget.AbsoluteLayout] extends TraitViewGroup[V] {
+@deprecated("", "") trait TraitAbsoluteLayout[V <: android.widget.AbsoluteLayout] extends TraitViewGroup[V] {
 
 }
 
 /**
  * Automatically generated concrete helper class of `[[https://developer.android.com/reference/android/widget/AbsoluteLayout.html android.widget.AbsoluteLayout]]`.
  */
-class SAbsoluteLayout()(implicit context: android.content.Context, parentVGroup: TraitViewGroup[_] = null)
+@deprecated("", "") class SAbsoluteLayout()(implicit context: android.content.Context, parentVGroup: TraitViewGroup[_] = null)
     extends android.widget.AbsoluteLayout(context) with TraitAbsoluteLayout[SAbsoluteLayout] {
 
   def basis = this
@@ -419,7 +419,7 @@ class SAbsoluteLayout()(implicit context: android.content.Context, parentVGroup:
 
 }
 
-object SAbsoluteLayout {
+@deprecated("", "") object SAbsoluteLayout {
   def apply[LP <: ViewGroupLayoutParams[_, SAbsoluteLayout]]()(implicit context: android.content.Context, defaultLayoutParam: SAbsoluteLayout => LP): SAbsoluteLayout = {
     val v = new SAbsoluteLayout
     v.<<.parent.+=(v)
@@ -540,7 +540,7 @@ trait TraitListView[V <: android.widget.ListView] extends TraitAbsListView[V] {
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/widget/ListView.html#getCheckItemIds() getCheckItemIds()]]`
    */
-  @inline def checkItemIds = basis.getCheckItemIds
+  @deprecated("", "") @inline def checkItemIds = basis.getCheckItemIds
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/widget/ListView.html#getDivider() getDivider()]]`
@@ -797,12 +797,12 @@ trait TraitImageView[V <: android.widget.ImageView] extends TraitView[V] {
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/widget/ImageView.html#setAlpha(int) setAlpha(int)]]`
    */
-  @inline def alpha(p: Int) = alpha_=(p)
+  @deprecated("", "") @inline def alpha(p: Int) = alpha_=(p)
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/widget/ImageView.html#setAlpha(int) setAlpha(int)]]`
    */
-  @inline def alpha_=(p: Int) = { basis.setAlpha(p); basis }
+  @deprecated("", "") @inline def alpha_=(p: Int) = { basis.setAlpha(p); basis }
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/widget/ImageView.html#setBaseline(int) setBaseline(int)]]`
@@ -7687,12 +7687,12 @@ object SZoomButton {
 /**
  * Automatically generated enriching class of `[[https://developer.android.com/reference/android/widget/Gallery.html android.widget.Gallery]]`.
  */
-class RichGallery[V <: android.widget.Gallery](val basis: V) extends TraitGallery[V]
+@deprecated("", "") class RichGallery[V <: android.widget.Gallery](val basis: V) extends TraitGallery[V]
 
 /**
  * Automatically generated helper trait of `[[https://developer.android.com/reference/android/widget/Gallery.html android.widget.Gallery]]`. This contains several property accessors.
  */
-trait TraitGallery[V <: android.widget.Gallery] extends TraitAbsSpinner[V] {
+@deprecated("", "") trait TraitGallery[V <: android.widget.Gallery] extends TraitAbsSpinner[V] {
 
   @inline def animationDuration(implicit no: NoGetterForThisProperty): Nothing = throw new Error("Android does not support the getter for 'animationDuration'")
 
@@ -7759,7 +7759,7 @@ trait TraitGallery[V <: android.widget.Gallery] extends TraitAbsSpinner[V] {
 /**
  * Automatically generated concrete helper class of `[[https://developer.android.com/reference/android/widget/Gallery.html android.widget.Gallery]]`.
  */
-class SGallery()(implicit context: android.content.Context, parentVGroup: TraitViewGroup[_] = null)
+@deprecated("", "") class SGallery()(implicit context: android.content.Context, parentVGroup: TraitViewGroup[_] = null)
     extends android.widget.Gallery(context) with TraitGallery[SGallery] {
 
   def basis = this
@@ -7767,7 +7767,7 @@ class SGallery()(implicit context: android.content.Context, parentVGroup: TraitV
 
 }
 
-object SGallery {
+@deprecated("", "") object SGallery {
   def apply[LP <: ViewGroupLayoutParams[_, SGallery]]()(implicit context: android.content.Context, defaultLayoutParam: SGallery => LP): SGallery = {
     val v = new SGallery
     v.<<.parent.+=(v)
@@ -8074,7 +8074,7 @@ trait TraitFrameLayout[V <: android.widget.FrameLayout] extends TraitViewGroup[V
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/widget/FrameLayout.html#getConsiderGoneChildrenWhenMeasuring() getConsiderGoneChildrenWhenMeasuring()]]`
    */
-  @inline def considerGoneChildrenWhenMeasuring = basis.getConsiderGoneChildrenWhenMeasuring
+  @deprecated("", "") @inline def considerGoneChildrenWhenMeasuring = basis.getConsiderGoneChildrenWhenMeasuring
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/widget/FrameLayout.html#getForeground() getForeground()]]`
@@ -9724,12 +9724,12 @@ trait TraitAutoCompleteTextView[V <: android.widget.AutoCompleteTextView] extend
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/widget/AutoCompleteTextView.html#getItemClickListener() getItemClickListener()]]`
    */
-  @inline def itemClickListener = basis.getItemClickListener
+  @deprecated("", "") @inline def itemClickListener = basis.getItemClickListener
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/widget/AutoCompleteTextView.html#getItemSelectedListener() getItemSelectedListener()]]`
    */
-  @inline def itemSelectedListener = basis.getItemSelectedListener
+  @deprecated("", "") @inline def itemSelectedListener = basis.getItemSelectedListener
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/widget/AutoCompleteTextView.html#getListSelection() getListSelection()]]`
@@ -11236,12 +11236,12 @@ trait TraitWebView[V <: android.webkit.WebView] extends TraitAbsoluteLayout[V] {
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/webkit/WebView.html#setPictureListener(android.webkit.WebView.PictureListener) setPictureListener(android.webkit.WebView.PictureListener)]]`
    */
-  @inline def pictureListener(p: android.webkit.WebView.PictureListener) = pictureListener_=(p)
+  @deprecated("", "") @inline def pictureListener(p: android.webkit.WebView.PictureListener) = pictureListener_=(p)
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/webkit/WebView.html#setPictureListener(android.webkit.WebView.PictureListener) setPictureListener(android.webkit.WebView.PictureListener)]]`
    */
-  @inline def pictureListener_=(p: android.webkit.WebView.PictureListener) = { basis.setPictureListener(p); basis }
+  @deprecated("", "") @inline def pictureListener_=(p: android.webkit.WebView.PictureListener) = { basis.setPictureListener(p); basis }
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/webkit/WebView.html#getProgress() getProgress()]]`
@@ -11283,7 +11283,7 @@ trait TraitWebView[V <: android.webkit.WebView] extends TraitAbsoluteLayout[V] {
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/webkit/WebView.html#getVisibleTitleHeight() getVisibleTitleHeight()]]`
    */
-  @inline def visibleTitleHeight = basis.getVisibleTitleHeight
+  @deprecated("", "") @inline def visibleTitleHeight = basis.getVisibleTitleHeight
 
   @inline def webChromeClient(implicit no: NoGetterForThisProperty): Nothing = throw new Error("Android does not support the getter for 'webChromeClient'")
 
@@ -11337,14 +11337,14 @@ trait TraitWebView[V <: android.webkit.WebView] extends TraitAbsoluteLayout[V] {
     basis
   }
 
-  @inline def onNewPicture[U](f: (android.webkit.WebView, android.graphics.Picture) => U): V = {
+  @deprecated("", "") @inline def onNewPicture[U](f: (android.webkit.WebView, android.graphics.Picture) => U): V = {
     basis.setPictureListener(new android.webkit.WebView.PictureListener {
       def onNewPicture(p1: android.webkit.WebView, p2: android.graphics.Picture): Unit = { f(p1, p2) }
     })
     basis
   }
 
-  @inline def onNewPicture[U](f: => U): V = {
+  @deprecated("", "") @inline def onNewPicture[U](f: => U): V = {
     basis.setPictureListener(new android.webkit.WebView.PictureListener {
       def onNewPicture(p1: android.webkit.WebView, p2: android.graphics.Picture): Unit = { f }
     })
@@ -11538,17 +11538,17 @@ trait TraitPaint[V <: android.graphics.Paint] {
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/graphics/Paint.html#isLinearText() isLinearText()]]`
    */
-  @inline def linearText = basis.isLinearText
+  @deprecated("", "") @inline def linearText = basis.isLinearText
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/graphics/Paint.html#setLinearText(boolean) setLinearText(boolean)]]`
    */
-  @inline def linearText(p: Boolean) = linearText_=(p)
+  @deprecated("", "") @inline def linearText(p: Boolean) = linearText_=(p)
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/graphics/Paint.html#setLinearText(boolean) setLinearText(boolean)]]`
    */
-  @inline def linearText_=(p: Boolean) = { basis.setLinearText(p); basis }
+  @deprecated("", "") @inline def linearText_=(p: Boolean) = { basis.setLinearText(p); basis }
 
   /**
    * Shortcut for `[[https://developer.android.com/reference/android/graphics/Paint.html#getMaskFilter() getMaskFilter()]]`
@@ -11850,7 +11850,7 @@ object SPaint {
 trait WidgetImplicits {
   @inline implicit def popupWindow2RichPopupWindow[V <: android.widget.PopupWindow](popupWindow: V) = new RichPopupWindow[V](popupWindow)
   @inline implicit def arrayAdapter2RichArrayAdapter[V <: android.widget.ArrayAdapter[_]](arrayAdapter: V) = new RichArrayAdapter[V](arrayAdapter)
-  @inline implicit def absoluteLayout2RichAbsoluteLayout[V <: android.widget.AbsoluteLayout](absoluteLayout: V) = new RichAbsoluteLayout[V](absoluteLayout)
+  @deprecated("", "") @inline implicit def absoluteLayout2RichAbsoluteLayout[V <: android.widget.AbsoluteLayout](absoluteLayout: V) = new RichAbsoluteLayout[V](absoluteLayout)
   @inline implicit def spinnerAdapter2RichSpinnerAdapter[V <: android.widget.SpinnerAdapter](spinnerAdapter: V) = new RichSpinnerAdapter[V](spinnerAdapter)
   @inline implicit def imageButton2RichImageButton[V <: android.widget.ImageButton](imageButton: V) = new RichImageButton[V](imageButton)
   @inline implicit def listView2RichListView[V <: android.widget.ListView](listView: V) = new RichListView[V](listView)
@@ -11927,7 +11927,7 @@ trait WidgetImplicits {
   @inline implicit def baseExpandableListAdapter2RichBaseExpandableListAdapter[V <: android.widget.BaseExpandableListAdapter](baseExpandableListAdapter: V) = new RichBaseExpandableListAdapter[V](baseExpandableListAdapter)
   @inline implicit def viewSwitcher2RichViewSwitcher[V <: android.widget.ViewSwitcher](viewSwitcher: V) = new RichViewSwitcher[V](viewSwitcher)
   @inline implicit def zoomButton2RichZoomButton[V <: android.widget.ZoomButton](zoomButton: V) = new RichZoomButton[V](zoomButton)
-  @inline implicit def gallery2RichGallery[V <: android.widget.Gallery](gallery: V) = new RichGallery[V](gallery)
+  @deprecated("", "") @inline implicit def gallery2RichGallery[V <: android.widget.Gallery](gallery: V) = new RichGallery[V](gallery)
   @inline implicit def filterQueryProvider2RichFilterQueryProvider[V <: android.widget.FilterQueryProvider](filterQueryProvider: V) = new RichFilterQueryProvider[V](filterQueryProvider)
   @inline implicit def popupMenu2RichPopupMenu[V <: android.widget.PopupMenu](popupMenu: V) = new RichPopupMenu[V](popupMenu)
   @inline implicit def compoundButton2RichCompoundButton[V <: android.widget.CompoundButton](compoundButton: V) = new RichCompoundButton[V](compoundButton)

--- a/scaloid-common/src/main/scala/org/scaloid/util/Configuration.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/util/Configuration.scala
@@ -27,7 +27,7 @@ object Configuration {
 
   @inline def landscape(implicit context: Context): Boolean = orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
 
-  @inline def square(implicit context: Context): Boolean = orientation == android.content.res.Configuration.ORIENTATION_SQUARE
+  @deprecated("", "") @inline def square(implicit context: Context): Boolean = orientation == android.content.res.Configuration.ORIENTATION_SQUARE
 
   @inline def long(implicit context: Context): Boolean = (conf.screenLayout & android.content.res.Configuration.SCREENLAYOUT_LONG_YES) != 0
 

--- a/scaloid-common/src/main/st/org/scaloid/common/SystemServices.scala
+++ b/scaloid-common/src/main/st/org/scaloid/common/SystemServices.scala
@@ -34,6 +34,8 @@ trait SystemServices {
   $android.app.ActivityManager; format="system-service"$
   $android.app.AlarmManager; format="system-service"$
   $android.media.AudioManager; format="system-service"$
+
+  // android.content.ClipboardManager in API 11+, but this is its superclass
   $android.text.ClipboardManager; format="system-service"$
 
   class RichClipboardManager(cm: android.text.ClipboardManager) {

--- a/scaloid-common/src/main/st/org/scaloid/common/view.scala.stg
+++ b/scaloid-common/src/main/st/org/scaloid/common/view.scala.stg
@@ -10,7 +10,7 @@ View_traitBody() ::= <<
   basis.getId
 }
 
-val FILL_PARENT = ViewGroup.LayoutParams.FILL_PARENT
+@deprecated("", "") val FILL_PARENT = ViewGroup.LayoutParams.FILL_PARENT
 val MATCH_PARENT = ViewGroup.LayoutParams.MATCH_PARENT
 val WRAP_CONTENT = ViewGroup.LayoutParams.WRAP_CONTENT
 

--- a/scaloid-common/src/main/st/org/scaloid/util/Configuration.scala
+++ b/scaloid-common/src/main/st/org/scaloid/util/Configuration.scala
@@ -27,7 +27,7 @@ object Configuration {
 
   @inline def landscape(implicit context: Context): Boolean = orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
 
-  @inline def square(implicit context: Context): Boolean = orientation == android.content.res.Configuration.ORIENTATION_SQUARE
+  @deprecated("", "") @inline def square(implicit context: Context): Boolean = orientation == android.content.res.Configuration.ORIENTATION_SQUARE
 
   @inline def long(implicit context: Context): Boolean = (conf.screenLayout & android.content.res.Configuration.SCREENLAYOUT_LONG_YES) != 0
 


### PR DESCRIPTION
There are various Android APIs which have been deprecated over time,
and the deprecation warnings are masked by scaloid. This means that
code using scaloid won't see the deprecation warnings intended by
the Android API libraries.

So here, note the deprecated elements and mark the corresponding
scaloid elements as deprecated. This both silences most of the
compile-time deprecation warnings for scaloid itself, and creates
deprecation warnings in scaloid-using code. No deprecation message
is included (it's just @deprecated("","")).

Note that this makes the generated code dependent on the highest
API level available in $ANDROID_HOME, as that will be used to mark
elements as deprecated. So along with this change, contributor wiki
instructions should be updated to indicate the API level in use by
the scaloid maintainer -- so that scaloid:generate produces the
correct annotations for the newest public Android API.

Along with this change, update some non-generated code with
explicit @deprecated annotations for things deprecated as of API 21.

ClipboardManager is explicitly not deprecated as it changed in
API 11 with a richer, but compatible, subclass of the original.