### PR TITLE
Update DisplayMetrics values to add XXXHDPI and TVDPI.

### DIFF
--- a/scaloid-common/src/main/scala/org/scaloid/util/Configuration.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/util/Configuration.scala
@@ -47,7 +47,11 @@ object Configuration {
 
   val HDPI = DisplayMetrics.DENSITY_HIGH
 
-  val XHDPI = 320 // DisplayMetrics.DENSITY_XHIGH  // heigher than API level 9
+  val TVDPI = 213 // DisplayMetrics.DENSITY_TV // added in API level 13
 
-  val XXHDPI = 480 // DisplayMetrics.DENSITY_XHIGH  // heigher than API level 16
+  val XHDPI = DisplayMetrics.DENSITY_XHIGH
+
+  val XXHDPI = 480 // DisplayMetrics.DENSITY_XXHIGH // added in API level 16
+
+  val XXXHDPI = 640 // DisplayMetrics.DENSITY_XXXHIGH // added in API level 18
 }

--- a/scaloid-common/src/main/st/org/scaloid/util/Configuration.scala
+++ b/scaloid-common/src/main/st/org/scaloid/util/Configuration.scala
@@ -47,7 +47,11 @@ object Configuration {
 
   val HDPI = DisplayMetrics.DENSITY_HIGH
 
-  val XHDPI = 320 // DisplayMetrics.DENSITY_XHIGH  // heigher than API level 9
+  val TVDPI = 213 // DisplayMetrics.DENSITY_TV // added in API level 13
 
-  val XXHDPI = 480 // DisplayMetrics.DENSITY_XHIGH  // heigher than API level 16
+  val XHDPI = DisplayMetrics.DENSITY_XHIGH
+
+  val XXHDPI = 480 // DisplayMetrics.DENSITY_XXHIGH // added in API level 16
+
+  val XXXHDPI = 640 // DisplayMetrics.DENSITY_XXXHIGH // added in API level 18
 }


### PR DESCRIPTION
While here, use DisplayMetrics.XHIGH directly (scaloid now requires
API level >= 10).