### PR TITLE
Add @unchecked to match expressions where scaloid can't guarantee typing.

### DIFF
--- a/scaloid-common/src/main/scala/org/scaloid/common/preferences.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/preferences.scala
@@ -63,7 +63,7 @@ class Preferences(val preferences: SharedPreferences) extends Dynamic {
       case v: Long => preferences.edit().putLong(name, v).commit()
       case v: Boolean => preferences.edit().putBoolean(name, v).commit()
       case v: Float => preferences.edit().putFloat(name, v).commit()
-      case v: Set[String] => preferences.edit().putStringSet(name, v).commit()
+      case v: Set[String @unchecked] => preferences.edit().putStringSet(name, v).commit()
     }
   }
 
@@ -73,7 +73,7 @@ class Preferences(val preferences: SharedPreferences) extends Dynamic {
     case v: Long => preferences.getLong(name, v).asInstanceOf[T]
     case v: Boolean => preferences.getBoolean(name, v).asInstanceOf[T]
     case v: Float => preferences.getFloat(name, v).asInstanceOf[T]
-    case v: Set[String] => preferences.getStringSet(name, v).toSet.asInstanceOf[T]
+    case v: Set[String @unchecked] => preferences.getStringSet(name, v).toSet.asInstanceOf[T]
   }
 
   def remove(name: String) {

--- a/scaloid-common/src/main/scala/org/scaloid/common/widget.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/widget.scala
@@ -1399,7 +1399,7 @@ class STableLayout()(implicit context: android.content.Context, parentVGroup: Tr
   def basis = this
   override val parentViewGroup = parentVGroup
   implicit def defaultLayoutParams[V <: View](v: V): LayoutParams[V] = v.getLayoutParams() match {
-    case p: LayoutParams[V] => p
+    case p: LayoutParams[V @unchecked] => p
     case _ => new LayoutParams(v)
   }
 
@@ -2366,7 +2366,7 @@ class SRelativeLayout()(implicit context: android.content.Context, parentVGroup:
   def basis = this
   override val parentViewGroup = parentVGroup
   implicit def defaultLayoutParams[V <: View](v: V): LayoutParams[V] = v.getLayoutParams() match {
-    case p: LayoutParams[V] => p
+    case p: LayoutParams[V @unchecked] => p
     case _ => new LayoutParams(v)
   }
 
@@ -5431,7 +5431,7 @@ class SLinearLayout()(implicit context: android.content.Context, parentVGroup: T
   val HORIZONTAL = LinearLayout.HORIZONTAL
 
   implicit def defaultLayoutParams[V <: View](v: V): LayoutParams[V] = v.getLayoutParams() match {
-    case p: LayoutParams[V] => p
+    case p: LayoutParams[V @unchecked] => p
     case _ => new LayoutParams(v)
   }
 
@@ -6529,7 +6529,7 @@ class STableRow()(implicit context: android.content.Context, parentVGroup: Trait
   def basis = this
   override val parentViewGroup = parentVGroup
   implicit def defaultLayoutParams[V <: View](v: V): LayoutParams[V] = v.getLayoutParams() match {
-    case p: LayoutParams[V] => p
+    case p: LayoutParams[V @unchecked] => p
     case _ => new LayoutParams(v)
   }
 
@@ -8132,7 +8132,7 @@ class SFrameLayout()(implicit context: android.content.Context, parentVGroup: Tr
   def basis = this
   override val parentViewGroup = parentVGroup
   implicit def defaultLayoutParams[V <: View](v: V): LayoutParams[V] = v.getLayoutParams() match {
-    case p: LayoutParams[V] => p
+    case p: LayoutParams[V @unchecked] => p
     case _ => new LayoutParams(v)
   }
 

--- a/scaloid-common/src/main/st/org/scaloid/common/preferences.scala
+++ b/scaloid-common/src/main/st/org/scaloid/common/preferences.scala
@@ -31,7 +31,7 @@ class Preferences(val preferences: SharedPreferences) extends Dynamic {
       case v: Boolean => preferences.edit().putBoolean(name, v).commit()
       case v: Float => preferences.edit().putFloat(name, v).commit()
 $if(ver.gte_11)$
-      case v: Set[String] => preferences.edit().putStringSet(name, v).commit()
+      case v: Set[String @unchecked] => preferences.edit().putStringSet(name, v).commit()
 $endif$
     }
   }
@@ -43,7 +43,7 @@ $endif$
     case v: Boolean => preferences.getBoolean(name, v).asInstanceOf[T]
     case v: Float => preferences.getFloat(name, v).asInstanceOf[T]
 $if(ver.gte_11)$
-    case v: Set[String] => preferences.getStringSet(name, v).toSet.asInstanceOf[T]
+    case v: Set[String @unchecked] => preferences.getStringSet(name, v).toSet.asInstanceOf[T]
 $endif$
   }
 

--- a/scaloid-common/src/main/st/org/scaloid/common/widget.scala.stg
+++ b/scaloid-common/src/main/st/org/scaloid/common/widget.scala.stg
@@ -1,6 +1,6 @@
 FrameLayout_concreteBody() ::= <<
 implicit def defaultLayoutParams[V <: View](v: V): LayoutParams[V] = v.getLayoutParams() match {
-  case p: LayoutParams[V] => p
+  case p: LayoutParams[V @unchecked] => p
   case _ => new LayoutParams(v)
 }
 
@@ -65,7 +65,7 @@ import android.graphics.drawable.Drawable
 
 RelativeLayout_concreteBody() ::= <<
 implicit def defaultLayoutParams[V <: View](v: V): LayoutParams[V] = v.getLayoutParams() match {
-  case p: LayoutParams[V] => p
+  case p: LayoutParams[V @unchecked] => p
   case _ => new LayoutParams(v)
 }
 
@@ -192,7 +192,7 @@ val VERTICAL = LinearLayout.VERTICAL
 val HORIZONTAL = LinearLayout.HORIZONTAL
 
 implicit def defaultLayoutParams[V <: View](v: V): LayoutParams[V] = v.getLayoutParams() match {
-  case p: LayoutParams[V] => p
+  case p: LayoutParams[V @unchecked] => p
   case _ => new LayoutParams(v)
 }
 
@@ -221,7 +221,7 @@ class LayoutParams[V <: View](v: V) extends LinearLayout.LayoutParams(MATCH_PARE
 
 TableLayout_concreteBody() ::= <<
 implicit def defaultLayoutParams[V <: View](v: V): LayoutParams[V] = v.getLayoutParams() match {
-  case p: LayoutParams[V] => p
+  case p: LayoutParams[V @unchecked] => p
   case _ => new LayoutParams(v)
 }
 
@@ -238,7 +238,7 @@ class LayoutParams[V <: View](v: V) extends TableLayout.LayoutParams(MATCH_PAREN
 
 TableRow_concreteBody() ::= <<
 implicit def defaultLayoutParams[V <: View](v: V): LayoutParams[V] = v.getLayoutParams() match {
-  case p: LayoutParams[V] => p
+  case p: LayoutParams[V @unchecked] => p
   case _ => new LayoutParams(v)
 }
 


### PR DESCRIPTION
This quiets down scaloid's build a bit, but still depends on the user code
supplying correctly typed values to the methods.