### PR TITLE
Provide an alternate SActivity.onCreate {} which provides the Bundle.

### DIFF
--- a/scaloid-common/src/main/scala/org/scaloid/common/app.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/app.scala
@@ -105,6 +105,18 @@ trait TraitActivity[V <: Activity] {
  *   onCreate(doSomething())
  * }}}
  *
+ * If the `Bundle` is needed in the `onCreate` call to restore saved state, a function can be supplied which accepts
+ * `Option[Bundle]`:
+ *
+ * {{{
+ *   onCreate { ob: Option[Bundle] =>
+ *     // do something for onCreate
+ *     ob.foreach { b =>
+ *       // do things if bundle was defined at onCreate time
+ *     }
+ *   }
+ * }}}
+ *
  * In contrast of method overriding, this shortcut can be called multiple times from different places of your code.
  *
  */
@@ -128,7 +140,17 @@ trait SActivity extends Activity with SContext with TraitActivity[SActivity] wit
 
   protected override def onCreate(b: Bundle) {
     super.onCreate(b)
-    onCreateBodies.foreach(_())
+    AppHelpers.createBundle.withValue(Option(b)) {
+      onCreateBodies.foreach(_())
+    }
+  }
+
+  def onCreate(body: Option[Bundle] => Any) = {
+    val el = { () =>
+      body(AppHelpers.createBundle.value)
+    }
+    onCreateBodies += el
+    el
   }
 
   override def onStart {

--- a/scaloid-common/src/main/scala/org/scaloid/common/helpers.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/helpers.scala
@@ -44,6 +44,7 @@ import android.widget._
 import android.view._
 import scala.concurrent.Future
 import scala.reflect._
+import scala.util.DynamicVariable
 
 trait AppHelpers {
 
@@ -82,6 +83,8 @@ trait AppHelpers {
 
   @inline def pendingActivity[T](implicit context: Context, ct: ClassTag[T]) =
     PendingIntent.getActivity(context, 0, SIntent[T], 0)
+
+  private[scaloid] val createBundle = new DynamicVariable[Option[android.os.Bundle]](None)
 
 }
 

--- a/scaloid-common/src/main/st/org/scaloid/common/app.scala
+++ b/scaloid-common/src/main/st/org/scaloid/common/app.scala
@@ -73,6 +73,18 @@ trait TraitActivity[V <: Activity] {
  *   onCreate(doSomething())
  * }}}
  *
+ * If the `Bundle` is needed in the `onCreate` call to restore saved state, a function can be supplied which accepts
+ * `Option[Bundle]`:
+ *
+ * {{{
+ *   onCreate { ob: Option[Bundle] =>
+ *     // do something for onCreate
+ *     ob.foreach { b =>
+ *       // do things if bundle was defined at onCreate time
+ *     }
+ *   }
+ * }}}
+ *
  * In contrast of method overriding, this shortcut can be called multiple times from different places of your code.
  *
  */
@@ -96,7 +108,17 @@ trait SActivity extends Activity with SContext with TraitActivity[SActivity] wit
 
   protected override def onCreate(b: Bundle) {
     super.onCreate(b)
-    onCreateBodies.foreach(_ ())
+    AppHelpers.createBundle.withValue(Option(b)) {
+      onCreateBodies.foreach(_ ())
+    }
+  }
+
+  def onCreate(body: Option[Bundle] => Any) = {
+    val el = { () =>
+      body(AppHelpers.createBundle.value)
+    }
+    onCreateBodies += el
+    el
   }
 
   override def onStart {

--- a/scaloid-common/src/main/st/org/scaloid/common/helpers.scala
+++ b/scaloid-common/src/main/st/org/scaloid/common/helpers.scala
@@ -11,6 +11,7 @@ import android.widget._
 import android.view._
 import scala.concurrent.Future
 import scala.reflect._
+import scala.util.DynamicVariable
 
 trait AppHelpers {
 
@@ -50,6 +51,7 @@ trait AppHelpers {
   @inline def pendingActivity[T](implicit context: Context, ct: ClassTag[T]) =
     PendingIntent.getActivity(context, 0, SIntent[T], 0)
 
+  private[scaloid] val createBundle = new DynamicVariable[Option[android.os.Bundle]](None)
 
 }
 


### PR DESCRIPTION
This makes use of scala.util.DynamicVariable (based on
InheritableThreadLocal) to provide scoped access to the bundle argument
passed to onCreate(). This way, activities with saved instance state
can be restored using thunk blocks.
