### PR TITLE
Use partially applied function syntax to avoid wrapping by-name thunks.

### DIFF
--- a/scaloid-common/src/main/scala/org/scaloid/common/app.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/app.scala
@@ -139,7 +139,7 @@ trait SActivity extends Activity with SContext with TraitActivity[SActivity] wit
   protected val onStartBodies = new ArrayBuffer[() => Any]
 
   def onStart(body: => Any) = {
-    val el = (() => body)
+    val el = body _
     onStartBodies += el
     el
   }
@@ -152,7 +152,7 @@ trait SActivity extends Activity with SContext with TraitActivity[SActivity] wit
   protected val onResumeBodies = new ArrayBuffer[() => Any]
 
   def onResume(body: => Any) = {
-    val el = (() => body)
+    val el = body _
     onResumeBodies += el
     el
   }
@@ -165,7 +165,7 @@ trait SActivity extends Activity with SContext with TraitActivity[SActivity] wit
   protected val onPauseBodies = new ArrayBuffer[() => Any]
 
   def onPause(body: => Any) = {
-    val el = (() => body)
+    val el = body _
     onPauseBodies += el
     el
   }
@@ -178,7 +178,7 @@ trait SActivity extends Activity with SContext with TraitActivity[SActivity] wit
   protected val onStopBodies = new ArrayBuffer[() => Any]
 
   def onStop(body: => Any) = {
-    val el = (() => body)
+    val el = body _
     onStopBodies += el
     el
   }

--- a/scaloid-common/src/main/scala/org/scaloid/common/content.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/content.scala
@@ -69,7 +69,7 @@ trait Destroyable {
   protected val onDestroyBodies = new ArrayBuffer[() => Any]
 
   def onDestroy(body: => Any) = {
-    val el = (() => body)
+    val el = body _
     onDestroyBodies += el
     el
   }
@@ -82,7 +82,7 @@ trait Creatable {
   protected val onCreateBodies = new ArrayBuffer[() => Any]
 
   def onCreate(body: => Any) = {
-    val el = (() => body)
+    val el = body _
     onCreateBodies += el
     el
   }

--- a/scaloid-common/src/main/st/org/scaloid/common/app.scala
+++ b/scaloid-common/src/main/st/org/scaloid/common/app.scala
@@ -107,7 +107,7 @@ trait SActivity extends Activity with SContext with TraitActivity[SActivity] wit
   protected val onStartBodies = new ArrayBuffer[() => Any]
 
   def onStart(body: => Any) = {
-    val el = (() => body)
+    val el = body _
     onStartBodies += el
     el
   }
@@ -120,7 +120,7 @@ trait SActivity extends Activity with SContext with TraitActivity[SActivity] wit
   protected val onResumeBodies = new ArrayBuffer[() => Any]
 
   def onResume(body: => Any) = {
-    val el = (() => body)
+    val el = body _
     onResumeBodies += el
     el
   }
@@ -133,7 +133,7 @@ trait SActivity extends Activity with SContext with TraitActivity[SActivity] wit
   protected val onPauseBodies = new ArrayBuffer[() => Any]
 
   def onPause(body: => Any) = {
-    val el = (() => body)
+    val el = body _
     onPauseBodies += el
     el
   }
@@ -146,7 +146,7 @@ trait SActivity extends Activity with SContext with TraitActivity[SActivity] wit
   protected val onStopBodies = new ArrayBuffer[() => Any]
 
   def onStop(body: => Any) = {
-    val el = (() => body)
+    val el = body _
     onStopBodies += el
     el
   }

--- a/scaloid-common/src/main/st/org/scaloid/common/content.scala
+++ b/scaloid-common/src/main/st/org/scaloid/common/content.scala
@@ -36,7 +36,7 @@ trait Destroyable {
   protected val onDestroyBodies = new ArrayBuffer[() => Any]
 
   def onDestroy(body: => Any) = {
-    val el = (() => body)
+    val el = body _
     onDestroyBodies += el
     el
   }
@@ -49,7 +49,7 @@ trait Creatable {
   protected val onCreateBodies = new ArrayBuffer[() => Any]
 
   def onCreate(body: => Any) = {
-    val el = (() => body)
+    val el = body _
     onCreateBodies += el
     el
   }


### PR DESCRIPTION
Given a by-name block named "thunk", the syntax

  (() => thunk)

wraps the thunk in an extra Function0 object. However, by-name thunks
are already Function0 instances, so a micro-optimization can be done by
using the syntax

  thunk _

This tells the compiler that the by-name thunk should be partially
applied (retained as an explicit function, not executed). This removes
one layer of call indirection for the on*() callbacks in SActivity and
other Creatable/Destroyable classes.