### PR TITLE
Configure external links in ScalaDoc

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,3 +8,5 @@ libraryDependencies ++= Seq(
 )
 
 addSbtPlugin("com.danieltrinh" % "sbt-scalariform" % "1.4.0")
+
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "0.2.2")


### PR DESCRIPTION
Right now [scaloid's Scaladoc](docs.scaloid.org/common/latest/) does not link to Scala standard library and other dependencies. This would bother scaloid starters because they may be not experienced Scala programmers.

This patch fixes these links in ScalaDoc.