### PR TITLE
Added action support for binding intent in a LocalServiceConnection

### DIFF
--- a/scaloid-common/src/main/scala/org/scaloid/common/content.scala
+++ b/scaloid-common/src/main/scala/org/scaloid/common/content.scala
@@ -397,7 +397,7 @@ class RichIntent(val intent: Intent) {
  *
  * [[http://blog.scaloid.org/2013/03/introducing-localservice.html]]
  */
-class LocalServiceConnection[S <: LocalService](bindFlag: Int = Context.BIND_AUTO_CREATE)(implicit ctx: Context, reg: Registerable, mf: ClassTag[S]) extends ServiceConnection {
+class LocalServiceConnection[S <: LocalService](bindFlag: Int = Context.BIND_AUTO_CREATE, bindAction: Option[String] = None)(implicit ctx: Context, reg: Registerable, mf: ClassTag[S]) extends ServiceConnection {
   var service: Option[S] = None
   var componentName: ComponentName = _
   var binder: IBinder = _
@@ -469,7 +469,8 @@ class LocalServiceConnection[S <: LocalService](bindFlag: Int = Context.BIND_AUT
   def connected: Boolean = service.isDefined
 
   reg.onRegister {
-    ctx.bindService(SIntent[S], this, bindFlag)
+    val intent = bindAction.map(SIntent[S](_)).getOrElse(SIntent[S])
+    ctx.bindService(intent, this, bindFlag)
   }
 
   reg.onUnregister {


### PR DESCRIPTION
Extras won't be seen in `onBind` method of a Service according to [Android Documentation](https://developer.android.com/reference/android/app/Service.html#onBind%28android.content.Intent%29)
However, the action string can be seen and might be useful for initializing objects in the Service `onBind` method.
